### PR TITLE
Scale large image when loading in accordance with OpenGL texture size listriction

### DIFF
--- a/lib/src/main/java/com/soundcloud/android/crop/HighlightView.java
+++ b/lib/src/main/java/com/soundcloud/android/crop/HighlightView.java
@@ -330,10 +330,10 @@ class HighlightView {
         mContext.invalidate();
     }
 
-    // Returns the cropping rectangle in image space
-    public Rect getCropRect() {
-        return new Rect((int) mCropRect.left, (int) mCropRect.top,
-                        (int) mCropRect.right, (int) mCropRect.bottom);
+    // Returns the cropping rectangle in image space with specified scale
+    public Rect getScaledCropRect(float scale) {
+        return new Rect((int) (mCropRect.left * scale), (int) (mCropRect.top * scale),
+                (int) (mCropRect.right * scale), (int) (mCropRect.bottom * scale));
     }
 
     // Maps the cropping rectangle from image space to screen space


### PR DESCRIPTION
This PR should fix https://github.com/jdamcd/android-crop/issues/17

ImageView internally use OpenGL to draw bitmap and OpenGL has its max texture size (typically 2048x2048).
If you want to set too large image to your imageview, it won't throw error. It just log warning like "[WARN] :   OpenGLRenderer: Bitmap too large to be uploaded into a texture" and doesn't display the bitmap.

This PR set inSampleSize parameter if image is larger than maximum texture size.
