### PR TITLE
Fallback to support getting images from Google Drive

### DIFF
--- a/lib/src/main/java/com/soundcloud/android/crop/CropImageActivity.java
+++ b/lib/src/main/java/com/soundcloud/android/crop/CropImageActivity.java
@@ -122,7 +122,7 @@ public class CropImageActivity extends MonitoredActivity {
 
         sourceUri = intent.getData();
         if (sourceUri != null) {
-            exifRotation = CropUtil.getExifRotation(CropUtil.getFromMediaUri(getContentResolver(), sourceUri));
+            exifRotation = CropUtil.getExifRotation(CropUtil.getFromMediaUri(this, getContentResolver(), sourceUri));
 
             InputStream is = null;
             try {
@@ -421,8 +421,8 @@ public class CropImageActivity extends MonitoredActivity {
             if (!IN_MEMORY_CROP) {
                 // In-memory crop negates the rotation
                 CropUtil.copyExifRotation(
-                        CropUtil.getFromMediaUri(getContentResolver(), sourceUri),
-                        CropUtil.getFromMediaUri(getContentResolver(), saveUri)
+                        CropUtil.getFromMediaUri(this, getContentResolver(), sourceUri),
+                        CropUtil.getFromMediaUri(this, getContentResolver(), saveUri)
                 );
             }
 

--- a/lib/src/main/java/com/soundcloud/android/crop/CropUtil.java
+++ b/lib/src/main/java/com/soundcloud/android/crop/CropUtil.java
@@ -18,15 +18,21 @@ package com.soundcloud.android.crop;
 
 import android.app.ProgressDialog;
 import android.content.ContentResolver;
+import android.content.Context;
 import android.database.Cursor;
 import android.media.ExifInterface;
 import android.net.Uri;
 import android.os.Handler;
+import android.os.ParcelFileDescriptor;
 import android.provider.MediaStore;
 import android.text.TextUtils;
 
 import java.io.Closeable;
 import java.io.File;
+import java.io.FileDescriptor;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 import java.io.IOException;
 
 /*
@@ -81,7 +87,7 @@ class CropUtil {
         }
     }
 
-    public static File getFromMediaUri(ContentResolver resolver, Uri uri) {
+    public static File getFromMediaUri(Context context, ContentResolver resolver, Uri uri) {
         if (uri == null) return null;
 
         if (SCHEME_FILE.equals(uri.getScheme())) {
@@ -103,6 +109,9 @@ class CropUtil {
                         }
                     }
                 }
+            } catch (IllegalArgumentException ignored) {
+                // See: https://github.com/jdamcd/android-crop/issues/47
+                return getFromMediaUriPfd(context, resolver, uri);
             } catch (SecurityException ignored) {
                 // Nothing we can do
             } finally {
@@ -110,6 +119,40 @@ class CropUtil {
             }
         }
         return null;
+    }
+
+    private static String getTempFilename(Context context) throws IOException {
+      File outputDir = context.getCacheDir(); // context being the Activity pointer
+      File outputFile = File.createTempFile("prefix", "extension", outputDir);
+      return outputFile.getAbsolutePath();
+    }
+
+    private static File getFromMediaUriPfd(Context context, ContentResolver resolver, Uri uri) {
+      if (uri == null) return null;
+
+      FileInputStream input = null;
+      FileOutputStream output = null;
+      try {
+        ParcelFileDescriptor pfd = resolver.openFileDescriptor(uri, "r");
+        FileDescriptor fd = pfd.getFileDescriptor();
+        input = new FileInputStream(fd);
+
+        String tempFilename = getTempFilename(context);
+        output = new FileOutputStream(tempFilename);
+
+        int read = 0;
+        byte[] bytes = new byte[4096];
+        while ((read = input.read(bytes)) != -1) {
+          output.write(bytes, 0, read);
+        }
+        return new File(tempFilename);
+      } catch (IOException ignored) {
+        // nothing we can do
+      } finally {
+        if (input != null) try { input.close(); } catch(Exception ignored) {}
+        if (output != null) try { output.close(); } catch(Exception ignored) {}
+      }
+      return null;
     }
 
     public static void startBackgroundJob(MonitoredActivity activity,

--- a/lib/src/main/java/com/soundcloud/android/crop/CropUtil.java
+++ b/lib/src/main/java/com/soundcloud/android/crop/CropUtil.java
@@ -123,7 +123,7 @@ class CropUtil {
 
     private static String getTempFilename(Context context) throws IOException {
       File outputDir = context.getCacheDir(); // context being the Activity pointer
-      File outputFile = File.createTempFile("prefix", "extension", outputDir);
+      File outputFile = File.createTempFile("image", "tmp", outputDir);
       return outputFile.getAbsolutePath();
     }
 


### PR DESCRIPTION
A fix for:  https://github.com/jdamcd/android-crop/issues/47

Unlike https://github.com/jdamcd/android-crop/pull/64 this pull avoids changing existing behaviour for non google drive images, and avoids recompressing (and potentially changing) the images.

Unfortunately I had to thread Context down to the bottom so we could get a temp filename.