### PR TITLE
Flag to set initial crop bounds to image bounds

### DIFF
--- a/lib/src/main/java/com/soundcloud/android/crop/Crop.java
+++ b/lib/src/main/java/com/soundcloud/android/crop/Crop.java
@@ -20,7 +20,6 @@ public class Crop {
     public static final int REQUEST_PICK = 9162;
     public static final int RESULT_ERROR = 404;
 
-
     static interface Extra {
         String ASPECT_X = "aspect_x";
         String ASPECT_Y = "aspect_y";

--- a/lib/src/main/java/com/soundcloud/android/crop/Crop.java
+++ b/lib/src/main/java/com/soundcloud/android/crop/Crop.java
@@ -20,11 +20,13 @@ public class Crop {
     public static final int REQUEST_PICK = 9162;
     public static final int RESULT_ERROR = 404;
 
+
     static interface Extra {
         String ASPECT_X = "aspect_x";
         String ASPECT_Y = "aspect_y";
         String MAX_X = "max_x";
         String MAX_Y = "max_y";
+        String DEFAULT_NO_CROP = "default_no_crop";
         String ERROR = "error";
     }
 
@@ -81,6 +83,16 @@ public class Crop {
         cropIntent.putExtra(Extra.MAX_X, width);
         cropIntent.putExtra(Extra.MAX_Y, height);
         return this;
+    }
+
+    /**
+     * If true then in the UI default to no crop, eg set the crop box to bounds of image
+     *
+     * @param defaultNoCrop True if you'd like the crop box to default to the image bounds
+     */
+    public Crop withDefaultNoCrop(boolean defaultNoCrop) {
+      cropIntent.putExtra(Extra.DEFAULT_NO_CROP, defaultNoCrop);
+      return this;
     }
 
     /**

--- a/lib/src/main/java/com/soundcloud/android/crop/CropImageActivity.java
+++ b/lib/src/main/java/com/soundcloud/android/crop/CropImageActivity.java
@@ -124,7 +124,7 @@ public class CropImageActivity extends MonitoredActivity {
 
         sourceUri = intent.getData();
         if (sourceUri != null) {
-            exifRotation = CropUtil.getExifRotation(CropUtil.getFromMediaUri(this, getContentResolver(), sourceUri));
+            exifRotation = CropUtil.getExifRotation(CropUtil.getFromMediaUri(getContentResolver(), sourceUri));
 
             InputStream is = null;
             try {
@@ -427,8 +427,8 @@ public class CropImageActivity extends MonitoredActivity {
             if (!IN_MEMORY_CROP) {
                 // In-memory crop negates the rotation
                 CropUtil.copyExifRotation(
-                        CropUtil.getFromMediaUri(this, getContentResolver(), sourceUri),
-                        CropUtil.getFromMediaUri(this, getContentResolver(), saveUri)
+                        CropUtil.getFromMediaUri(getContentResolver(), sourceUri),
+                        CropUtil.getFromMediaUri(getContentResolver(), saveUri)
                 );
             }
 


### PR DESCRIPTION
For my use case most users do not need the image cropped, and some were cropping their images without meaning to since the default crop bounds is not the image bounds.

This new flag lets you set the initial crop bounds to be the image bounds.  Default behaviour is unchanged.

See: https://github.com/jdamcd/android-crop/issues/66
