### PR TITLE
'Show circle' feature.

### DIFF
--- a/example/src/main/res/values/theme.xml
+++ b/example/src/main/res/values/theme.xml
@@ -6,6 +6,7 @@
 
     <style name="Widget.CropImageView" parent="android:Widget">
         <item name="showThirds">true</item>
+        <item name="showCircle">true</item>
         <item name="showHandles">always</item>
         <item name="highlightColor">@color/highlight</item>
     </style>

--- a/lib/src/main/java/com/soundcloud/android/crop/HighlightView.java
+++ b/lib/src/main/java/com/soundcloud/android/crop/HighlightView.java
@@ -66,6 +66,7 @@ class HighlightView {
 
     private View viewContext; // View displaying image
     private boolean showThirds;
+    private boolean showCircle;
     private int highlightColor;
 
     private ModifyMode modifyMode = ModifyMode.None;
@@ -87,6 +88,7 @@ class HighlightView {
         TypedArray attributes = context.obtainStyledAttributes(outValue.resourceId, R.styleable.CropImageView);
         try {
             showThirds = attributes.getBoolean(R.styleable.CropImageView_showThirds, false);
+            showCircle = attributes.getBoolean(R.styleable.CropImageView_showCircle, false);
             highlightColor = attributes.getColor(R.styleable.CropImageView_highlightColor,
                     DEFAULT_HIGHLIGHT_COLOR);
             handleMode = HandleMode.values()[attributes.getInt(R.styleable.CropImageView_showHandles, 0)];
@@ -150,6 +152,10 @@ class HighlightView {
                 drawThirds(canvas);
             }
 
+            if (showCircle) {
+                drawCircle(canvas);
+            }
+
             if (handleMode == HandleMode.Always ||
                     (handleMode == HandleMode.Changing && modifyMode == ModifyMode.Grow)) {
                 drawHandles(canvas);
@@ -207,6 +213,11 @@ class HighlightView {
                 drawRect.right, drawRect.top + yThird, outlinePaint);
         canvas.drawLine(drawRect.left, drawRect.top + yThird * 2,
                 drawRect.right, drawRect.top + yThird * 2, outlinePaint);
+    }
+
+    private void drawCircle(Canvas canvas) {
+        outlinePaint.setStrokeWidth(1);
+        canvas.drawOval(new RectF(drawRect), outlinePaint);
     }
 
     public void setMode(ModifyMode mode) {

--- a/lib/src/main/res/values/attrs.xml
+++ b/lib/src/main/res/values/attrs.xml
@@ -5,6 +5,7 @@
     <declare-styleable name="CropImageView">
         <attr name="highlightColor" format="reference|color" />
         <attr name="showThirds" format="boolean" />
+        <attr name="showCircle" format="boolean" />
         <attr name="showHandles">
           <enum name="changing" value="0" />
           <enum name="always" value="1" />


### PR DESCRIPTION
This optionally draws a circle in the HighlightView, in the same style as the 'thirds'.
This is useful as many apps use circle avatars nowadays.  Also useful to crop images
that will be shown on a round watch.