### PR TITLE
Specify aspect ratio as one value rather than as two integers

### DIFF
--- a/lib/src/androidTest/java/com/soundcloud/android/crop/CropBuilderTest.java
+++ b/lib/src/androidTest/java/com/soundcloud/android/crop/CropBuilderTest.java
@@ -43,8 +43,7 @@ public class CropBuilderTest extends BaseTestCase {
 
         Intent intent = builder.getIntent(activity);
 
-        assertThat(intent.getIntExtra("aspect_x", 0)).isEqualTo(16);
-        assertThat(intent.getIntExtra("aspect_y", 0)).isEqualTo(10);
+        assertThat(intent.getDoubleExtra("aspect_ratio", 0)).isEqualTo(1.6);
     }
 
     public void testFixedAspectRatioSetAsExtras() {
@@ -52,8 +51,7 @@ public class CropBuilderTest extends BaseTestCase {
 
         Intent intent = builder.getIntent(activity);
 
-        assertThat(intent.getIntExtra("aspect_x", 0)).isEqualTo(1);
-        assertThat(intent.getIntExtra("aspect_y", 0)).isEqualTo(1);
+        assertThat(intent.getDoubleExtra("aspect_ratio", 0)).isEqualTo(1);
     }
 
     public void testMaxSizeSetAsExtras() {
@@ -70,8 +68,7 @@ public class CropBuilderTest extends BaseTestCase {
 
         Intent intent = builder.getIntent(activity);
 
-        assertThat(intent.getIntExtra("aspect_x", 0)).isEqualTo(1);
-        assertThat(intent.getIntExtra("aspect_y", 0)).isEqualTo(1);
+        assertThat(intent.getDoubleExtra("aspect_ratio", 0)).isEqualTo(1);
         assertThat(intent.getIntExtra("max_x", 0)).isEqualTo(200);
         assertThat(intent.getIntExtra("max_y", 0)).isEqualTo(200);
     }

--- a/lib/src/main/java/com/soundcloud/android/crop/Crop.java
+++ b/lib/src/main/java/com/soundcloud/android/crop/Crop.java
@@ -21,8 +21,7 @@ public class Crop {
     public static final int RESULT_ERROR = 404;
 
     static interface Extra {
-        String ASPECT_X = "aspect_x";
-        String ASPECT_Y = "aspect_y";
+        String ASPECT_RATIO = "aspect_ratio";
         String MAX_X = "max_x";
         String MAX_Y = "max_y";
         String ERROR = "error";
@@ -57,8 +56,16 @@ public class Crop {
      * @param y Aspect Y
      */
     public Crop withAspect(int x, int y) {
-        cropIntent.putExtra(Extra.ASPECT_X, x);
-        cropIntent.putExtra(Extra.ASPECT_Y, y);
+        return this.withAspect((double) x / (double) y);
+    }
+
+    /**
+     * Set fixed aspect ratio for crop area; the aspect ratio is defined as {@code width / height}.
+     *
+     * @param aspectRatio the aspect ratio for the crop area (definied as width divided by height)
+     */
+    public Crop withAspect(final double aspectRatio) {
+        cropIntent.putExtra(Extra.ASPECT_RATIO, aspectRatio);
         return this;
     }
 
@@ -66,8 +73,7 @@ public class Crop {
      * Crop area with fixed 1:1 aspect ratio
      */
     public Crop asSquare() {
-        cropIntent.putExtra(Extra.ASPECT_X, 1);
-        cropIntent.putExtra(Extra.ASPECT_Y, 1);
+        cropIntent.putExtra(Extra.ASPECT_RATIO, 1.0);
         return this;
     }
 

--- a/lib/src/main/java/com/soundcloud/android/crop/CropImageActivity.java
+++ b/lib/src/main/java/com/soundcloud/android/crop/CropImageActivity.java
@@ -48,10 +48,11 @@ public class CropImageActivity extends MonitoredActivity {
     private static final int SIZE_DEFAULT = 2048;
     private static final int SIZE_LIMIT = 4096;
 
+    private static final double NO_ASPECT_RATIO_SPECIFIED = Double.NaN;
+
     private final Handler handler = new Handler();
 
-    private int aspectX;
-    private int aspectY;
+    private double aspectRatio;
 
     // Output image
     private int maxX;
@@ -113,8 +114,7 @@ public class CropImageActivity extends MonitoredActivity {
         Bundle extras = intent.getExtras();
 
         if (extras != null) {
-            aspectX = extras.getInt(Crop.Extra.ASPECT_X);
-            aspectY = extras.getInt(Crop.Extra.ASPECT_Y);
+            aspectRatio = extras.getDouble(Crop.Extra.ASPECT_RATIO, NO_ASPECT_RATIO_SPECIFIED);
             maxX = extras.getInt(Crop.Extra.MAX_X);
             maxY = extras.getInt(Crop.Extra.MAX_Y);
             saveUri = extras.getParcelable(MediaStore.EXTRA_OUTPUT);
@@ -224,11 +224,11 @@ public class CropImageActivity extends MonitoredActivity {
             @SuppressWarnings("SuspiciousNameCombination")
             int cropHeight = cropWidth;
 
-            if (aspectX != 0 && aspectY != 0) {
-                if (aspectX > aspectY) {
-                    cropHeight = cropWidth * aspectY / aspectX;
+            if (aspectRatio != NO_ASPECT_RATIO_SPECIFIED) {
+                if (aspectRatio > 1) {
+                    cropHeight = (int) Math.round((double)cropWidth / aspectRatio);
                 } else {
-                    cropWidth = cropHeight * aspectX / aspectY;
+                    cropWidth = (int) Math.round(cropHeight * aspectRatio);
                 }
             }
 
@@ -236,7 +236,7 @@ public class CropImageActivity extends MonitoredActivity {
             int y = (height - cropHeight) / 2;
 
             RectF cropRect = new RectF(x, y, x + cropWidth, y + cropHeight);
-            hv.setup(imageView.getUnrotatedMatrix(), imageRect, cropRect, aspectX != 0 && aspectY != 0);
+            hv.setup(imageView.getUnrotatedMatrix(), imageRect, cropRect, aspectRatio != NO_ASPECT_RATIO_SPECIFIED);
             imageView.add(hv);
         }
 


### PR DESCRIPTION
At the end of the day, an aspect ratio is just that: a ratio. We don't strictly need to represent it as two X/Y values. This pull request:

1. Treats aspect ratio as a single value internally and
2. Allows callers to set the aspect ratio as a single `double` value rather than as two `int` values

This change should be entirely backwards compatible.