### PR TITLE
Remove "allowBackup" from AndroidManifest

### DIFF
--- a/lib/src/main/AndroidManifest.xml
+++ b/lib/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.soundcloud.android.crop">
 
-    <application
-        android:allowBackup="true" />
+    <application />
 
 </manifest>


### PR DESCRIPTION
Library should not specify an `allowBackup` value as it can conflict with app's setting (manifest merger will complain).