### PR TITLE
Fix output size (Crop is then just a region selector)

### DIFF
--- a/lib/src/main/java/com/soundcloud/android/crop/Crop.java
+++ b/lib/src/main/java/com/soundcloud/android/crop/Crop.java
@@ -89,6 +89,8 @@ public class Crop {
      * client application a desired width and height... user won't be able to resize
      * Highlighted zone, just move it.
      *
+     * The region specified is the target output fixed dimension, not screen dimensions.
+     *
      * Note: this behaviour is incompatible with {@link #withMaxSize(int, int)}
      *
      * @param fixedWidth the with of the result

--- a/lib/src/main/java/com/soundcloud/android/crop/Crop.java
+++ b/lib/src/main/java/com/soundcloud/android/crop/Crop.java
@@ -21,11 +21,12 @@ public class Crop {
     static interface Extra {
         String ASPECT_X = "aspect_x";
         String ASPECT_Y = "aspect_y";
-        String MAX_X = "max_x";
-        String MAX_Y = "max_y";
-        String ERROR = "error";
-        String FIX_X = "fix_x";
-        String FIX_Y = "fix_y";
+        String MAX_X    = "max_x";
+        String MAX_Y    = "max_y";
+        String ERROR    = "error";
+        String FIX_X    = "fix_x";
+        String FIX_Y    = "fix_y";
+        String FIX_MIN  = "fix_min";
     }
 
     private Intent cropIntent;
@@ -103,6 +104,17 @@ public class Crop {
         cropIntent.putExtra(Extra.FIX_X, fixedWidth);
         cropIntent.putExtra(Extra.FIX_Y, fixedHeight);
         return this;
+    }
+
+    /**
+     * Set up the crop to just crop (not resize) bound to the minimum image dimension, and as a square region.
+     */
+    public Crop fixToMin() {
+        if (cropIntent.hasExtra(Extra.MAX_X)) {
+            throw new IllegalStateException("maximum dimensions already defined, cannot use fixed dimensions now");
+        }
+        cropIntent.putExtra(Extra.FIX_MIN, true);
+        return this.asSquare();
     }
 
     /**

--- a/lib/src/main/java/com/soundcloud/android/crop/Crop.java
+++ b/lib/src/main/java/com/soundcloud/android/crop/Crop.java
@@ -24,6 +24,8 @@ public class Crop {
         String MAX_X = "max_x";
         String MAX_Y = "max_y";
         String ERROR = "error";
+        String FIX_X = "fix_x";
+        String FIX_Y = "fix_y";
     }
 
     private Intent cropIntent;
@@ -68,12 +70,36 @@ public class Crop {
     /**
      * Set maximum crop size
      *
+     * Incompatible with {@link #fixedRegion(int, int)}
+     *
      * @param width Max width
      * @param height Max height
      */
     public Crop withMaxSize(int width, int height) {
+        if (cropIntent.hasExtra(Extra.FIX_X)) {
+            throw new IllegalStateException("fixed dimensions specified, cannot set max size then");
+        }
         cropIntent.putExtra(Extra.MAX_X, width);
         cropIntent.putExtra(Extra.MAX_Y, height);
+        return this;
+    }
+
+    /**
+     * Enable the cropper to be used just as a image region selector, ensuring
+     * client application a desired width and height... user won't be able to resize
+     * Highlighted zone, just move it.
+     *
+     * Note: this behaviour is incompatible with {@link #withMaxSize(int, int)}
+     *
+     * @param fixedWidth the with of the result
+     * @param fixedHeight the height of the result
+     */
+    public Crop fixedRegion(int fixedWidth, int fixedHeight) {
+        if (cropIntent.hasExtra(Extra.MAX_X)) {
+            throw new IllegalStateException("maximum dimensions already defined, cannot use fixed dimensions now");
+        }
+        cropIntent.putExtra(Extra.FIX_X, fixedWidth);
+        cropIntent.putExtra(Extra.FIX_Y, fixedHeight);
         return this;
     }
 

--- a/lib/src/main/java/com/soundcloud/android/crop/CropImageActivity.java
+++ b/lib/src/main/java/com/soundcloud/android/crop/CropImageActivity.java
@@ -56,6 +56,9 @@ public class CropImageActivity extends MonitoredActivity {
     private int fixedX;
     private int fixedY;
 
+    // Extra options
+    private boolean fixToMin;
+
 
     private Uri sourceUri;
     private Uri saveUri;
@@ -118,6 +121,7 @@ public class CropImageActivity extends MonitoredActivity {
             maxY = extras.getInt(Crop.Extra.MAX_Y);
             fixedX = extras.getInt(Crop.Extra.FIX_X);
             fixedY = extras.getInt(Crop.Extra.FIX_Y);
+            fixToMin = extras.getBoolean(Crop.Extra.FIX_MIN, false);
             saveUri = extras.getParcelable(MediaStore.EXTRA_OUTPUT);
         }
 
@@ -222,6 +226,11 @@ public class CropImageActivity extends MonitoredActivity {
 
             int cropWidth;
             int cropHeight;
+
+            if (fixToMin) {
+                fixedX = fixedY = sampleSize * Math.min(width, height);
+            }
+
             if (fixedY != 0 && fixedX != 0) {
                 cropWidth = Math.min(width, fixedX / sampleSize);
                 cropHeight = Math.min(height, fixedY / sampleSize);

--- a/lib/src/main/java/com/soundcloud/android/crop/CropImageActivity.java
+++ b/lib/src/main/java/com/soundcloud/android/crop/CropImageActivity.java
@@ -53,6 +53,9 @@ public class CropImageActivity extends MonitoredActivity {
     private int maxX;
     private int maxY;
     private int exifRotation;
+    private int fixedX;
+    private int fixedY;
+
 
     private Uri sourceUri;
     private Uri saveUri;
@@ -113,6 +116,8 @@ public class CropImageActivity extends MonitoredActivity {
             aspectY = extras.getInt(Crop.Extra.ASPECT_Y);
             maxX = extras.getInt(Crop.Extra.MAX_X);
             maxY = extras.getInt(Crop.Extra.MAX_Y);
+            fixedX = extras.getInt(Crop.Extra.FIX_X);
+            fixedY = extras.getInt(Crop.Extra.FIX_Y);
             saveUri = extras.getParcelable(MediaStore.EXTRA_OUTPUT);
         }
 
@@ -215,10 +220,18 @@ public class CropImageActivity extends MonitoredActivity {
 
             Rect imageRect = new Rect(0, 0, width, height);
 
-            // Make the default size about 4/5 of the width or height
-            int cropWidth = Math.min(width, height) * 4 / 5;
-            @SuppressWarnings("SuspiciousNameCombination")
-            int cropHeight = cropWidth;
+            int cropWidth;
+            int cropHeight;
+            if (fixedY != 0 && fixedX != 0) {
+                cropWidth = Math.min(width, fixedX);
+                cropHeight = Math.min(height, fixedY);
+            } else {
+
+                // Make the default size about 4/5 of the width or height
+                cropWidth = Math.min(width, height) * 4 / 5;
+
+                cropHeight = cropWidth;
+            }
 
             if (aspectX != 0 && aspectY != 0) {
                 if (aspectX > aspectY) {
@@ -232,7 +245,7 @@ public class CropImageActivity extends MonitoredActivity {
             int y = (height - cropHeight) / 2;
 
             RectF cropRect = new RectF(x, y, x + cropWidth, y + cropHeight);
-            hv.setup(imageView.getUnrotatedMatrix(), imageRect, cropRect, aspectX != 0 && aspectY != 0);
+            hv.setup(imageView.getUnrotatedMatrix(), imageRect, cropRect, aspectX != 0 && aspectY != 0, fixedX == 0 && fixedY == 0);
             imageView.add(hv);
         }
 

--- a/lib/src/main/java/com/soundcloud/android/crop/CropImageActivity.java
+++ b/lib/src/main/java/com/soundcloud/android/crop/CropImageActivity.java
@@ -223,8 +223,8 @@ public class CropImageActivity extends MonitoredActivity {
             int cropWidth;
             int cropHeight;
             if (fixedY != 0 && fixedX != 0) {
-                cropWidth = Math.min(width, fixedX);
-                cropHeight = Math.min(height, fixedY);
+                cropWidth = Math.min(width, fixedX / sampleSize);
+                cropHeight = Math.min(height, fixedY / sampleSize);
             } else {
 
                 // Make the default size about 4/5 of the width or height

--- a/lib/src/main/java/com/soundcloud/android/crop/HighlightView.java
+++ b/lib/src/main/java/com/soundcloud/android/crop/HighlightView.java
@@ -76,6 +76,7 @@ class HighlightView {
     private float handleRadius;
     private float outlineWidth;
     private boolean isFocused;
+    private boolean enableResize;
 
     public HighlightView(View context) {
         viewContext = context;
@@ -97,12 +98,13 @@ class HighlightView {
         }
     }
 
-    public void setup(Matrix m, Rect imageRect, RectF cropRect, boolean maintainAspectRatio) {
+    public void setup(Matrix m, Rect imageRect, RectF cropRect, boolean maintainAspectRatio, boolean enableResize) {
         matrix = new Matrix(m);
 
         this.cropRect = cropRect;
         this.imageRect = new RectF(imageRect);
         this.maintainAspectRatio = maintainAspectRatio;
+        this.enableResize = enableResize;
 
         initialAspectRatio = this.cropRect.width() / this.cropRect.height();
         drawRect = computeLayout();
@@ -232,6 +234,7 @@ class HighlightView {
         Rect r = computeLayout();
         final float hysteresis = 20F;
         int retval = GROW_NONE;
+        boolean allowFromEdges = false;
 
         // verticalCheck makes sure the position is between the top and
         // the bottom edge (with some tolerance). Similar for horizCheck.
@@ -254,8 +257,13 @@ class HighlightView {
             retval |= GROW_BOTTOM_EDGE;
         }
 
+        if (!enableResize && retval != GROW_NONE) {
+            // also allow movement from edges then...
+            allowFromEdges = true;
+        }
+
         // Not near any edge but inside the rectangle: move
-        if (retval == GROW_NONE && r.contains((int) x, (int) y)) {
+        if ((retval == GROW_NONE && r.contains((int) x, (int) y)) || allowFromEdges) {
             retval = MOVE;
         }
         return retval;


### PR DESCRIPTION
Patch to allow set a desired fixed dimension size (relative to output image), then user can only move the region but not resize it.

Sadly I've done this work because I didn't see in advance that there was already a PR with same purpose. 

This PR also adds the fix to smallest size method.

