### PR TITLE
re-add gingerbread support

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -7,7 +7,7 @@ android {
     buildToolsVersion '21.1.2'
 
     defaultConfig {
-        minSdkVersion 14
+        minSdkVersion 10
         targetSdkVersion 21
         versionCode Integer.parseInt(project.VERSION_CODE)
         versionName project.VERSION

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -10,7 +10,7 @@ android {
     buildToolsVersion '21.1.2'
 
     defaultConfig {
-        minSdkVersion 14
+        minSdkVersion 10
         targetSdkVersion 21
 
         testApplicationId 'com.soundcloud.android.crop.test'


### PR DESCRIPTION
Nothing in the code seems to rely on a minSdk of 14. There was one change that requires an API of 10, but switching from 9 to 14 was overkill!

Tested with the example, everything works as expected.