### PR TITLE
A bug about exifRotation

### DIFF
--- a/lib/src/main/java/com/soundcloud/android/crop/CropImageActivity.java
+++ b/lib/src/main/java/com/soundcloud/android/crop/CropImageActivity.java
@@ -325,7 +325,7 @@ public class CropImageActivity extends MonitoredActivity {
                 RectF adjusted = new RectF();
                 matrix.mapRect(adjusted, new RectF(rect));
 
-                //when your picture are not square,if the exifRotation is 90 or 270,
+                //if the cutting box are rectangle( outWidth != outHeight ),and the exifRotation is 90 or 270,
                 //the outWidth and outHeight showld be interchanged
                 if (exifRotation==90||exifRotation==270){
                     int temp=outWidth;
@@ -344,7 +344,12 @@ public class CropImageActivity extends MonitoredActivity {
                     Matrix matrix = new Matrix();
                     matrix.postScale((float) outWidth / rect.width(), (float) outHeight / rect.height());
 
-                    //if the picture's exifRotation !=0 ,they should be go to adjust
+                    //if the picture's exifRotation !=0 ,they should be rotate to 0 degrees
+                    matrix.postRotate(exifRotation);
+                    croppedImage = Bitmap.createBitmap(croppedImage, 0, 0, croppedImage.getWidth(), croppedImage.getHeight(), matrix, true);
+                }else{
+                    //if the picture need not to be scale, they also neet to be rotate to 0 degrees
+                    Matrix matrix = new Matrix();
                     matrix.postRotate(exifRotation);
                     croppedImage = Bitmap.createBitmap(croppedImage, 0, 0, croppedImage.getWidth(), croppedImage.getHeight(), matrix, true);
                 }

--- a/lib/src/main/java/com/soundcloud/android/crop/CropImageActivity.java
+++ b/lib/src/main/java/com/soundcloud/android/crop/CropImageActivity.java
@@ -325,6 +325,14 @@ public class CropImageActivity extends MonitoredActivity {
                 RectF adjusted = new RectF();
                 matrix.mapRect(adjusted, new RectF(rect));
 
+                //when your picture are not square,if the exifRotation is 90 or 270,
+                //the outWidth and outHeight showld be interchanged
+                if (exifRotation==90||exifRotation==270){
+                    int temp=outWidth;
+                    outWidth=outHeight;
+                    outHeight=temp;
+                }
+
                 // Adjust to account for origin at 0,0
                 adjusted.offset(adjusted.left < 0 ? width : 0, adjusted.top < 0 ? height : 0);
                 rect = new Rect((int) adjusted.left, (int) adjusted.top, (int) adjusted.right, (int) adjusted.bottom);
@@ -335,6 +343,9 @@ public class CropImageActivity extends MonitoredActivity {
                 if (rect.width() > outWidth || rect.height() > outHeight) {
                     Matrix matrix = new Matrix();
                     matrix.postScale((float) outWidth / rect.width(), (float) outHeight / rect.height());
+
+                    //if the picture's exifRotation !=0 ,they should be go to adjust
+                    matrix.postRotate(exifRotation);
                     croppedImage = Bitmap.createBitmap(croppedImage, 0, 0, croppedImage.getWidth(), croppedImage.getHeight(), matrix, true);
                 }
             } catch (IllegalArgumentException e) {


### PR DESCRIPTION
![p50724-103311](https://cloud.githubusercontent.com/assets/9404424/8866591/e58d4caa-31f0-11e5-93c0-1338a676aeb4.jpg)
![s50724-103321](https://cloud.githubusercontent.com/assets/9404424/8867012/83f88c6a-31f6-11e5-90e1-d0c9c8c43ee8.jpg)
![s50724-103329](https://cloud.githubusercontent.com/assets/9404424/8866593/e5dddefe-31f0-11e5-8c56-b231951ca283.jpg)
![s50724-103527](https://cloud.githubusercontent.com/assets/9404424/8866592/e5ddccc0-31f0-11e5-9a96-60f64200a3e1.jpg)

Bug1:when we set fixed aspect ratio ,if the crop are not square,and the exifRotation are 90 or 270,the crop will error.
Bug2:the return image show be adjust when the exifRotation are not 0.
