### PR TITLE
Fix NPE at croppedImage.getWidth() if decodeRegion returns null

### DIFF
--- a/lib/src/main/java/com/soundcloud/android/crop/CropImageActivity.java
+++ b/lib/src/main/java/com/soundcloud/android/crop/CropImageActivity.java
@@ -361,6 +361,9 @@ public class CropImageActivity extends MonitoredActivity {
         } catch (OutOfMemoryError e) {
             Log.e("OOM cropping image: " + e.getMessage(), e);
             setResultException(e);
+        } catch (NullPointerException e) {
+            Log.e("NPE cropping image: " + e.getMessage(), e);
+            setResultException(e);
         } finally {
             CropUtil.closeSilently(is);
         }


### PR DESCRIPTION
My application has gotten crashes sometimes by NPE at croppedImage.getWidth() of [this line](https://github.com/jdamcd/android-crop/blob/master/lib/src/main/java/com/soundcloud/android/crop/CropImageActivity.java#L350).

And BitmapRegionDecoder#decodeRegion comments below.
```
     * @return The decoded bitmap, or null if the image data could not be
     *         decoded.
```

I hope in that case CropImageActivity will return RESULT_ERROR.