### PR TITLE
Can specify resulting image to be saved as a PNG

### DIFF
--- a/lib/src/androidTest/java/com/soundcloud/android/crop/CropBuilderTest.java
+++ b/lib/src/androidTest/java/com/soundcloud/android/crop/CropBuilderTest.java
@@ -74,4 +74,11 @@ public class CropBuilderTest extends BaseTestCase {
         assertThat(intent.getIntExtra("max_y", 0)).isEqualTo(200);
     }
 
+    public void testAsPngSetAsExtras() {
+        builder.asPng(true);
+
+        Intent intent = builder.getIntent(activity);
+
+        assertThat(intent.getBooleanExtra("as_png", false)).isEqualTo(true);
+    }
 }

--- a/lib/src/main/java/com/soundcloud/android/crop/Crop.java
+++ b/lib/src/main/java/com/soundcloud/android/crop/Crop.java
@@ -25,6 +25,7 @@ public class Crop {
         String ASPECT_Y = "aspect_y";
         String MAX_X = "max_x";
         String MAX_Y = "max_y";
+        String AS_PNG = "as_png";
         String ERROR = "error";
     }
 
@@ -76,6 +77,15 @@ public class Crop {
     public Crop withMaxSize(int width, int height) {
         cropIntent.putExtra(Extra.MAX_X, width);
         cropIntent.putExtra(Extra.MAX_Y, height);
+        return this;
+    }
+
+    /**
+     * Set whether to save the result as a PNG or not. Helpful to preserve alpha.
+     * @param asPng whether to save the result as a PNG or not
+     */
+    public Crop asPng(boolean asPng) {
+        cropIntent.putExtra(Extra.AS_PNG, asPng);
         return this;
     }
 

--- a/lib/src/main/java/com/soundcloud/android/crop/CropImageActivity.java
+++ b/lib/src/main/java/com/soundcloud/android/crop/CropImageActivity.java
@@ -56,6 +56,7 @@ public class CropImageActivity extends MonitoredActivity {
     private int maxX;
     private int maxY;
     private int exifRotation;
+    private boolean saveAsPng;
 
     private Uri sourceUri;
     private Uri saveUri;
@@ -125,6 +126,7 @@ public class CropImageActivity extends MonitoredActivity {
             aspectY = extras.getInt(Crop.Extra.ASPECT_Y);
             maxX = extras.getInt(Crop.Extra.MAX_X);
             maxY = extras.getInt(Crop.Extra.MAX_Y);
+            saveAsPng = extras.getBoolean(Crop.Extra.AS_PNG, false);
             saveUri = extras.getParcelable(MediaStore.EXTRA_OUTPUT);
         }
 
@@ -381,7 +383,9 @@ public class CropImageActivity extends MonitoredActivity {
             try {
                 outputStream = getContentResolver().openOutputStream(saveUri);
                 if (outputStream != null) {
-                    croppedImage.compress(Bitmap.CompressFormat.JPEG, 90, outputStream);
+                    croppedImage.compress(saveAsPng ? Bitmap.CompressFormat.PNG : Bitmap.CompressFormat.JPEG,
+                            90,     // note: quality is ignored when using PNG
+                            outputStream);
                 }
             } catch (IOException e) {
                 setResultException(e);


### PR DESCRIPTION
Allows library to be used with images containing alpha. As-is, the
resulting cropped image will have black in place of alpha.