### PR TITLE
Using createScaledBitmap, using a scaled matrix and calling createBit…

### DIFF
--- a/lib/src/main/java/com/soundcloud/android/crop/Crop.java
+++ b/lib/src/main/java/com/soundcloud/android/crop/Crop.java
@@ -26,6 +26,19 @@ public class Crop {
         String MAX_X = "max_x";
         String MAX_Y = "max_y";
         String ERROR = "error";
+        String SCALE_METHOD = "scale_method";
+    }
+
+    public enum ScaleMethod {
+        /**
+         * Using the exact dimensions provided and using a scaling function for creating a scale bitmap. When scaling a large amount, the quality can suffer.
+         */
+        EXACT,
+        /**
+         * This approach uses sampling while decoding the image which provides better results; however, this requires the image be scaled by powers of 2 and cannot provide
+         * dimensions exactly requested. This will result in better quality images when the scale amount is large.
+         */
+        BETTER_QUALITY_BEST_FIT;
     }
 
     private Intent cropIntent;
@@ -44,6 +57,7 @@ public class Crop {
         cropIntent = new Intent();
         cropIntent.setData(source);
         cropIntent.putExtra(MediaStore.EXTRA_OUTPUT, destination);
+        cropIntent.putExtra(Extra.SCALE_METHOD, ScaleMethod.EXACT.ordinal());
     }
 
     /**
@@ -76,6 +90,16 @@ public class Crop {
     public Crop withMaxSize(int width, int height) {
         cropIntent.putExtra(Extra.MAX_X, width);
         cropIntent.putExtra(Extra.MAX_Y, height);
+        return this;
+    }
+
+    /**
+     * Set how the image will be scaled when providing {@link Extra#MAX_X} and {@link Extra#MAX_Y} with the {@link #withMaxSize(int, int)}
+     * @param type
+     * @return
+     */
+    public Crop withScaleMethod(ScaleMethod type) {
+        cropIntent.putExtra(Extra.SCALE_METHOD, type.ordinal());
         return this;
     }
 

--- a/lib/src/main/java/com/soundcloud/android/crop/CropImageActivity.java
+++ b/lib/src/main/java/com/soundcloud/android/crop/CropImageActivity.java
@@ -21,7 +21,9 @@ import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.BitmapRegionDecoder;
+import android.graphics.Canvas;
 import android.graphics.Matrix;
+import android.graphics.Paint;
 import android.graphics.Rect;
 import android.graphics.RectF;
 import android.net.Uri;
@@ -56,6 +58,7 @@ public class CropImageActivity extends MonitoredActivity {
     private int maxX;
     private int maxY;
     private int exifRotation;
+    private Crop.ScaleMethod scaleMethod;
 
     private Uri sourceUri;
     private Uri saveUri;
@@ -126,6 +129,7 @@ public class CropImageActivity extends MonitoredActivity {
             maxX = extras.getInt(Crop.Extra.MAX_X);
             maxY = extras.getInt(Crop.Extra.MAX_Y);
             saveUri = extras.getParcelable(MediaStore.EXTRA_OUTPUT);
+            scaleMethod = Crop.ScaleMethod.values()[extras.getInt(Crop.Extra.SCALE_METHOD, 0)];
         }
 
         sourceUri = intent.getData();
@@ -343,11 +347,29 @@ public class CropImageActivity extends MonitoredActivity {
             }
 
             try {
-                croppedImage = decoder.decodeRegion(rect, new BitmapFactory.Options());
-                if (croppedImage != null && (rect.width() > outWidth || rect.height() > outHeight)) {
-                    Matrix matrix = new Matrix();
-                    matrix.postScale((float) outWidth / rect.width(), (float) outHeight / rect.height());
-                    croppedImage = Bitmap.createBitmap(croppedImage, 0, 0, croppedImage.getWidth(), croppedImage.getHeight(), matrix, true);
+                BitmapFactory.Options options = new BitmapFactory.Options();
+                if ((rect.width() > outWidth || rect.height() > outHeight)) {
+                    switch (scaleMethod) {
+                        case EXACT:
+                            croppedImage = decoder.decodeRegion(rect, options);
+                            Matrix matrix = new Matrix();
+                            matrix.postScale((float) outWidth / rect.width(), (float) outHeight / rect.height());
+                            croppedImage = Bitmap.createBitmap(croppedImage, 0, 0, croppedImage.getWidth(), croppedImage.getHeight(), matrix, true);
+                            break;
+                        case BETTER_QUALITY_BEST_FIT:
+                            int w, h;
+                            int inSampleSize = 1;
+                            do {
+                                inSampleSize *= 2;
+                                w = rect.width() / inSampleSize;
+                                h = rect.height() / inSampleSize;
+                            } while(w > outWidth && h > outHeight);
+                            options.inSampleSize = inSampleSize;
+                            croppedImage = decoder.decodeRegion(rect, options);
+                            break;
+                    }
+                } else {
+                    croppedImage = decoder.decodeRegion(rect, options);
                 }
             } catch (IllegalArgumentException e) {
                 // Rethrow with some extra information
@@ -433,5 +455,4 @@ public class CropImageActivity extends MonitoredActivity {
     private void setResultException(Throwable throwable) {
         setResult(Crop.RESULT_ERROR, new Intent().putExtra(Crop.Extra.ERROR, throwable));
     }
-
 }


### PR DESCRIPTION
…map, and other methods involving scale always caused bad looking images. Using inSampleSize while decoding resulted in much better looking images. The only downside to using it is that you cannot get an exact dimension. This is because isSampleSize must be a power of 2. So if you aren't picky about the exact dimension of your final scaled image and want better quality, you can use withScaleMethod and specify BETTER_QUALITY_BEST_FIT. The default uses the traditional method.

I've attached two files. The file called matrixScaled.jpg is done with what the library originally does and sampleSizeDecoding.jp in an image using my proposed code.
![matrixscale](https://cloud.githubusercontent.com/assets/6502859/14898807/af901b5e-0d3d-11e6-9c9e-5f4113009f65.jpg)
![samplesizedecoding](https://cloud.githubusercontent.com/assets/6502859/14898806/af8f47e2-0d3d-11e6-87c3-aa23c3cbd2f5.jpg)

