### PR TITLE
Avoid image highlight staying behind soft navigation bar

### DIFF
--- a/lib/src/main/java/com/soundcloud/android/crop/CropImageView.java
+++ b/lib/src/main/java/com/soundcloud/android/crop/CropImageView.java
@@ -3,6 +3,7 @@ package com.soundcloud.android.crop;
 import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Rect;
+import android.os.Build;
 import android.support.annotation.NonNull;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
@@ -20,6 +21,8 @@ public class CropImageView extends ImageViewTouchBase {
     private int motionEdge;
     private int validPointerId;
 
+    private int softNavbarHeight = 0;
+
     public CropImageView(Context context) {
         super(context);
     }
@@ -35,6 +38,14 @@ public class CropImageView extends ImageViewTouchBase {
     @Override
     protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
         super.onLayout(changed, left, top, right, bottom);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+            int resID = getResources().getIdentifier("navigation_bar_height", "dimen", "android");
+            if(resID > 0){
+                softNavbarHeight = getResources().getDimensionPixelSize(resID) + 50;
+            }
+        }
+
         if (bitmapDisplayed.getBitmap() != null) {
             for (HighlightView hv : highlightViews) {
 
@@ -149,6 +160,9 @@ public class CropImageView extends ImageViewTouchBase {
         int panDeltaY = panDeltaY1 != 0 ? panDeltaY1 : panDeltaY2;
 
         if (panDeltaX != 0 || panDeltaY != 0) {
+            if(softNavbarHeight > 0 && panDeltaY < 0){
+                panDeltaY = panDeltaY - softNavbarHeight;
+            }
             panBy(panDeltaX, panDeltaY);
         }
     }


### PR DESCRIPTION
In Android devices that show soft navigation bar, when an image is zoomed-in and moved at the bottom, the highlighted image is overlapped from navigation bar