### PR TITLE
Uses ExifInterface from Support Library and saves output rotated without EXIF

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.0'
+        classpath 'com.android.tools.build:gradle:2.3.0'
     }
 }
 

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -19,11 +19,11 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-annotations:25.1.1'
-    compile 'com.android.support:support-v4:25.1.1'
-    compile 'com.android.support:exifinterface:25.1.1'
+    compile 'com.android.support:support-annotations:25.3.1'
+    compile 'com.android.support:support-v4:25.3.1'
+    compile 'com.android.support:exifinterface:25.3.1'
     androidTestCompile 'com.squareup:fest-android:1.0.7'
-    androidTestCompile 'com.android.support:support-v4:25.1.1'
+    androidTestCompile 'com.android.support:support-v4:25.3.1'
     androidTestCompile 'org.mockito:mockito-core:1.9.5'
     androidTestCompile 'com.google.dexmaker:dexmaker:1.0'
     androidTestCompile 'com.google.dexmaker:dexmaker-mockito:1.0'

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -19,11 +19,11 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-annotations:25.1.0'
-    compile 'com.android.support:support-v4:25.1.0'
-    compile 'com.android.support:exifinterface:25.1.0'
+    compile 'com.android.support:support-annotations:25.1.1'
+    compile 'com.android.support:support-v4:25.1.1'
+    compile 'com.android.support:exifinterface:25.1.1'
     androidTestCompile 'com.squareup:fest-android:1.0.7'
-    androidTestCompile 'com.android.support:support-v4:25.1.0'
+    androidTestCompile 'com.android.support:support-v4:25.1.1'
     androidTestCompile 'org.mockito:mockito-core:1.9.5'
     androidTestCompile 'com.google.dexmaker:dexmaker:1.0'
     androidTestCompile 'com.google.dexmaker:dexmaker-mockito:1.0'

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -6,12 +6,12 @@ apply plugin: 'signing'
 archivesBaseName = 'android-crop'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion '23.0.1'
+    compileSdkVersion 25
+    buildToolsVersion '25.0.2'
 
     defaultConfig {
         minSdkVersion 10
-        targetSdkVersion 22
+        targetSdkVersion 25
 
         testApplicationId 'com.soundcloud.android.crop.test'
         testInstrumentationRunner 'android.test.InstrumentationTestRunner'
@@ -19,10 +19,11 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-annotations:23.0.1'
-    compile 'com.android.support:support-v4:23.0.1'
+    compile 'com.android.support:support-annotations:25.1.0'
+    compile 'com.android.support:support-v4:25.1.0'
+    compile 'com.android.support:exifinterface:25.1.0'
     androidTestCompile 'com.squareup:fest-android:1.0.7'
-    androidTestCompile 'com.android.support:support-v4:23.0.1'
+    androidTestCompile 'com.android.support:support-v4:25.1.0'
     androidTestCompile 'org.mockito:mockito-core:1.9.5'
     androidTestCompile 'com.google.dexmaker:dexmaker:1.0'
     androidTestCompile 'com.google.dexmaker:dexmaker-mockito:1.0'

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -7,7 +7,7 @@ archivesBaseName = 'android-crop'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    buildToolsVersion '25.0.3'
 
     defaultConfig {
         minSdkVersion 10
@@ -19,11 +19,11 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-annotations:25.3.1'
-    compile 'com.android.support:support-v4:25.3.1'
-    compile 'com.android.support:exifinterface:25.3.1'
+    compile 'com.android.support:support-annotations:25.4.0'
+    compile 'com.android.support:support-v4:25.4.0'
+    compile 'com.android.support:exifinterface:25.4.0'
     androidTestCompile 'com.squareup:fest-android:1.0.7'
-    androidTestCompile 'com.android.support:support-v4:25.3.1'
+    androidTestCompile 'com.android.support:support-v4:25.4.0'
     androidTestCompile 'org.mockito:mockito-core:1.9.5'
     androidTestCompile 'com.google.dexmaker:dexmaker:1.0'
     androidTestCompile 'com.google.dexmaker:dexmaker-mockito:1.0'

--- a/lib/src/main/java/com/soundcloud/android/crop/CropUtil.java
+++ b/lib/src/main/java/com/soundcloud/android/crop/CropUtil.java
@@ -18,30 +18,19 @@ package com.soundcloud.android.crop;
 
 import android.app.ProgressDialog;
 import android.content.ContentResolver;
-import android.content.Context;
-import android.database.Cursor;
-import android.media.ExifInterface;
 import android.net.Uri;
 import android.os.Handler;
-import android.os.ParcelFileDescriptor;
-import android.provider.MediaStore;
 import android.support.annotation.Nullable;
-import android.text.TextUtils;
+import android.support.media.ExifInterface;
 
 import java.io.Closeable;
-import java.io.File;
-import java.io.FileDescriptor;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 
 /*
  * Modified from original in AOSP.
  */
 class CropUtil {
-
-    private static final String SCHEME_FILE = "file";
-    private static final String SCHEME_CONTENT = "content";
 
     public static void closeSilently(@Nullable Closeable c) {
         if (c == null) return;
@@ -52,10 +41,15 @@ class CropUtil {
         }
     }
 
-    public static int getExifRotation(File imageFile) {
-        if (imageFile == null) return 0;
+    public static int getExifRotation(ContentResolver contentResolver, Uri imageUri) {
+        if (imageUri == null) return 0;
+
+        InputStream inputStream = null;
         try {
-            ExifInterface exif = new ExifInterface(imageFile.getAbsolutePath());
+            inputStream = contentResolver.openInputStream(imageUri);
+            if (inputStream == null) return 0;
+
+            ExifInterface exif = new ExifInterface(inputStream);
             // We only recognize a subset of orientation tag values
             switch (exif.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_UNDEFINED)) {
                 case ExifInterface.ORIENTATION_ROTATE_90:
@@ -70,91 +64,9 @@ class CropUtil {
         } catch (IOException e) {
             Log.e("Error getting Exif data", e);
             return 0;
-        }
-    }
-
-    public static boolean copyExifRotation(File sourceFile, File destFile) {
-        if (sourceFile == null || destFile == null) return false;
-        try {
-            ExifInterface exifSource = new ExifInterface(sourceFile.getAbsolutePath());
-            ExifInterface exifDest = new ExifInterface(destFile.getAbsolutePath());
-            exifDest.setAttribute(ExifInterface.TAG_ORIENTATION, exifSource.getAttribute(ExifInterface.TAG_ORIENTATION));
-            exifDest.saveAttributes();
-            return true;
-        } catch (IOException e) {
-            Log.e("Error copying Exif data", e);
-            return false;
-        }
-    }
-
-    @Nullable
-    public static File getFromMediaUri(Context context, ContentResolver resolver, Uri uri) {
-        if (uri == null) return null;
-
-        if (SCHEME_FILE.equals(uri.getScheme())) {
-            return new File(uri.getPath());
-        } else if (SCHEME_CONTENT.equals(uri.getScheme())) {
-            final String[] filePathColumn = { MediaStore.MediaColumns.DATA, MediaStore.MediaColumns.DISPLAY_NAME };
-            Cursor cursor = null;
-            try {
-                cursor = resolver.query(uri, filePathColumn, null, null, null);
-                if (cursor != null && cursor.moveToFirst()) {
-                    final int columnIndex = (uri.toString().startsWith("content://com.google.android.gallery3d")) ?
-                            cursor.getColumnIndex(MediaStore.MediaColumns.DISPLAY_NAME) :
-                            cursor.getColumnIndex(MediaStore.MediaColumns.DATA);
-                    // Picasa images on API 13+
-                    if (columnIndex != -1) {
-                        String filePath = cursor.getString(columnIndex);
-                        if (!TextUtils.isEmpty(filePath)) {
-                            return new File(filePath);
-                        }
-                    }
-                }
-            } catch (IllegalArgumentException e) {
-                // Google Drive images
-                return getFromMediaUriPfd(context, resolver, uri);
-            } catch (SecurityException ignored) {
-                // Nothing we can do
-            } finally {
-                if (cursor != null) cursor.close();
-            }
-        }
-        return null;
-    }
-
-    private static String getTempFilename(Context context) throws IOException {
-        File outputDir = context.getCacheDir();
-        File outputFile = File.createTempFile("image", "tmp", outputDir);
-        return outputFile.getAbsolutePath();
-    }
-
-    @Nullable
-    private static File getFromMediaUriPfd(Context context, ContentResolver resolver, Uri uri) {
-        if (uri == null) return null;
-
-        FileInputStream input = null;
-        FileOutputStream output = null;
-        try {
-            ParcelFileDescriptor pfd = resolver.openFileDescriptor(uri, "r");
-            FileDescriptor fd = pfd.getFileDescriptor();
-            input = new FileInputStream(fd);
-
-            String tempFilename = getTempFilename(context);
-            output = new FileOutputStream(tempFilename);
-
-            int read;
-            byte[] bytes = new byte[4096];
-            while ((read = input.read(bytes)) != -1) {
-                output.write(bytes, 0, read);
-            }
-            return new File(tempFilename);
-        } catch (IOException ignored) {
-            // Nothing we can do
         } finally {
-            closeSilently(input);
-            closeSilently(output);
+            closeSilently(inputStream);
         }
-        return null;
     }
 
     public static void startBackgroundJob(MonitoredActivity activity,

--- a/lib/src/main/java/com/soundcloud/android/crop/HighlightView.java
+++ b/lib/src/main/java/com/soundcloud/android/crop/HighlightView.java
@@ -367,8 +367,8 @@ class HighlightView {
 
     // Returns the cropping rectangle in image space with specified scale
     public Rect getScaledCropRect(float scale) {
-        return new Rect((int) (cropRect.left * scale), (int) (cropRect.top * scale),
-                (int) (cropRect.right * scale), (int) (cropRect.bottom * scale));
+        return new Rect(Math.round(cropRect.left * scale), Math.round(cropRect.top * scale),
+                Math.round(cropRect.right * scale), Math.round(cropRect.bottom * scale));
     }
 
     // Maps the cropping rectangle from image space to screen space


### PR DESCRIPTION
This probably fixes a lot of issues users are having with wrong image rotation.

The Support Library was updated to 25.1.0, which includes a support ExifInterface.

Using ExifInterface from Support Library allows us to read the EXIF metadata from
any Uri (protocol independent, using ContentResolver.openInputStream).

For the same reason (to be protocol independent), the EXIF information is not copied
to the output anymore. Instead, the cropped image is rotated using Matrix.postRotate
(as a result of this, it is not necessary to rewrite the output just to copy the EXIF
rotation as done before).